### PR TITLE
Refactoring vec_ffi_vecstr

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -31,6 +31,7 @@
 use cxx::UniquePtr;
 
 use crate::config::{BatchType, Config};
+use crate::types::vec_ffi_vecstr;
 
 #[cxx::bridge]
 mod ffi {
@@ -112,7 +113,7 @@ impl Generator {
     /// like `<s>`, this token should be added to this input.
     pub fn generate_batch<T: AsRef<str>, U: AsRef<str>, V: AsRef<str>>(
         &self,
-        start_tokens: &[Vec<T>],
+        start_tokens: &Vec<Vec<T>>,
         options: &GenerationOptions<U, V>,
     ) -> anyhow::Result<Vec<GenerationResult>> {
         Ok(self
@@ -279,16 +280,6 @@ impl GenerationResult {
         !self.scores.is_empty()
     }
 }
-
-#[inline]
-fn vec_ffi_vecstr<T: AsRef<str>>(src: &[Vec<T>]) -> Vec<ffi::VecStr> {
-    src.iter()
-        .map(|v| ffi::VecStr {
-            v: v.iter().map(|s| s.as_ref()).collect(),
-        })
-        .collect()
-}
-
 
 #[cfg(test)]
 mod tests {

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -34,6 +34,7 @@
 use cxx::UniquePtr;
 
 use crate::config::{BatchType, Config};
+use crate::types::vec_ffi_vecstr;
 
 #[cxx::bridge]
 mod ffi {
@@ -255,8 +256,8 @@ impl Translator {
     /// Translates a batch of tokens.
     pub fn translate_batch<T, U, V>(
         &self,
-        source: &[Vec<T>],
-        target_prefix: &[Vec<U>],
+        source: &Vec<Vec<T>>,
+        target_prefix: &Vec<Vec<U>>,
         options: &TranslationOptions<V>,
     ) -> anyhow::Result<Vec<TranslationResult>>
         where
@@ -315,15 +316,6 @@ impl TranslationResult {
     pub fn has_scores(&self) -> bool {
         !self.scores.is_empty()
     }
-}
-
-#[inline]
-fn vec_ffi_vecstr<T: AsRef<str>>(src: &[Vec<T>]) -> Vec<ffi::VecStr> {
-    src.iter()
-        .map(|v| ffi::VecStr {
-            v: v.iter().map(|s| s.as_ref()).collect(),
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,9 +22,58 @@ pub(crate) mod ffi {
         v: Vec<usize>,
     }
 
-    struct _dummy<'a>{
+    struct _dummy<'a> {
         _vec_string: Vec<VecString>,
         _vec_str: Vec<VecStr<'a>>,
-        _vec_usize: Vec<VecUSize>
+        _vec_usize: Vec<VecUSize>,
+    }
+}
+
+#[inline]
+pub(crate) fn vec_ffi_vecstr<T: AsRef<str>>(src: &Vec<Vec<T>>) -> Vec<ffi::VecStr> {
+    src.iter()
+        .map(|v| ffi::VecStr {
+            v: v.iter().map(|s| s.as_ref()).collect(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::vec_ffi_vecstr;
+
+    #[test]
+    fn str_vectors() {
+        let data = vec![vec!["a", "b", "c"], vec!["1", "2"]];
+        let res = vec_ffi_vecstr(&data);
+
+        assert_eq!(res.len(), data.len());
+        for (i, list) in data.iter().enumerate() {
+            let v = &res.get(i).unwrap().v;
+            assert_eq!(v.len(), list.len());
+            for (j, s) in list.iter().enumerate() {
+                assert_eq!(v.get(j).unwrap(), s);
+            }
+        }
+    }
+
+    #[test]
+    fn empty_inner_vectors() {
+        let data:Vec<Vec<&str>> = vec![vec![], vec![]];
+        let res = vec_ffi_vecstr(&data);
+
+        assert_eq!(res.len(), data.len());
+        for (i, list) in data.iter().enumerate() {
+            let v = &res.get(i).unwrap().v;
+            assert_eq!(v.len(), 0);
+        }
+    }
+
+    #[test]
+    fn empty_vectors() {
+        let data:Vec<Vec<&str>> = vec![];
+        let res = vec_ffi_vecstr(&data);
+
+        assert_eq!(res.len(), 0);
     }
 }


### PR DESCRIPTION
It's moved to `types` mod so that `Translator` and `Generator` can use it. Also, tests for the function are added.