### PR TITLE
Accept mutable closures as callback functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/translator.cpp");
     println!("cargo:rerun-if-changed=src/generator.rs");
     println!("cargo:rerun-if-changed=src/generator.cpp");
-    println!("cargo:rerun-if-changed=include/convert.h");
+    println!("cargo:rerun-if-changed=include/types.h");
     println!("cargo:rerun-if-changed=include/config.h");
     println!("cargo:rerun-if-changed=include/translator.h");
     println!("cargo:rerun-if-changed=include/generator.h");

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -58,6 +58,7 @@ fn main() -> Result<()> {
             // include_prompt_in_result: false,
             ..GenerationOptions::default()
         },
+        None,
     )?;
     let mut out: BufWriter<Box<dyn Write>> = BufWriter::new(match args.output {
         None => Box::new(stdout()),

--- a/examples/marian-mt.rs
+++ b/examples/marian-mt.rs
@@ -8,7 +8,7 @@
 
 use std::fs::File;
 use std::io;
-use std::io::{stdout, BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufReader, BufWriter, stdout, Write};
 use std::time;
 
 use anyhow::Result;
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
         .collect::<std::result::Result<Vec<String>, io::Error>>()?;
 
     let now = time::Instant::now();
-    let res = t.translate_batch(&sources, &Default::default())?;
+    let res = t.translate_batch(&sources, &Default::default(), None)?;
     let elapsed = now.elapsed();
 
     let mut out: BufWriter<Box<dyn Write>> = BufWriter::new(match args.output {

--- a/examples/nllb.rs
+++ b/examples/nllb.rs
@@ -8,7 +8,7 @@
 
 use std::fs::File;
 use std::io;
-use std::io::{stdout, BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufReader, BufWriter, stdout, Write};
 use std::time;
 
 use anyhow::Result;
@@ -57,8 +57,12 @@ fn main() -> Result<()> {
     let target_prefixes = vec![vec![args.target]; sources.len()];
 
     let now = time::Instant::now();
-    let res =
-        t.translate_batch_with_target_prefix(&sources, &target_prefixes, &Default::default())?;
+    let res = t.translate_batch_with_target_prefix(
+        &sources,
+        &target_prefixes,
+        &Default::default(),
+        None,
+    )?;
     let elapsed = now.elapsed();
 
     let mut out: BufWriter<Box<dyn Write>> = BufWriter::new(match args.output {

--- a/include/convert.h
+++ b/include/convert.h
@@ -116,7 +116,7 @@ inline std::function<bool(ctranslate2::GenerationStepResult)> from_rust(bool has
             res.batch_id,
             res.token_id,
             res.hypothesis_id,
-            rust::Str(res.token),
+            rust::String(res.token),
             res.log_prob.has_value(),
             res.log_prob.value_or(0),
             res.is_last,

--- a/include/convert.h
+++ b/include/convert.h
@@ -104,22 +104,3 @@ inline rust::Vec<T> to_rust(const std::vector<std::vector<size_t>>& v) {
     }
     return res;
 }
-
-inline std::function<bool(ctranslate2::GenerationStepResult)> from_rust(bool has_callback, const rust::Fn<bool(GenerationStepResult)>& callback) {
-    if (!has_callback) {
-        return nullptr;
-    }
-
-    return [=](ctranslate2::GenerationStepResult res) -> bool {
-        return callback(GenerationStepResult {
-            res.step,
-            res.batch_id,
-            res.token_id,
-            res.hypothesis_id,
-            rust::String(res.token),
-            res.log_prob.has_value(),
-            res.log_prob.value_or(0),
-            res.is_last,
-        });
-    };
-}

--- a/include/generator.h
+++ b/include/generator.h
@@ -36,15 +36,15 @@ public:
         GenerationCallbackBox& callback
     ) const;
 
-    size_t num_queued_batches() const {
+    inline size_t num_queued_batches() const {
         return this->impl->num_queued_batches();
     }
 
-    size_t num_active_batches() const {
+    inline size_t num_active_batches() const {
         return this->impl->num_active_batches();
     }
 
-    size_t num_replicas() const {
+    inline size_t num_replicas() const {
         return this->impl->num_replicas();
     }
 };

--- a/include/generator.h
+++ b/include/generator.h
@@ -19,6 +19,7 @@ struct VecStr;
 struct GenerationOptions;
 struct GenerationResult;
 struct GenerationStepResult;
+struct GenerationCallbackBox;
 
 class Generator {
 private:
@@ -32,7 +33,7 @@ public:
         const rust::Vec<VecStr>& start_tokens,
         const GenerationOptions& options,
         bool has_callback,
-        rust::Fn<bool(GenerationStepResult)> callback
+        GenerationCallbackBox& callback
     ) const;
 
     size_t num_queued_batches() const {

--- a/include/translator.h
+++ b/include/translator.h
@@ -19,7 +19,7 @@ struct VecStr;
 struct TranslationOptions;
 struct TranslationResult;
 struct GenerationStepResult;
-struct DynCallback;
+struct TranslationCallbackBox;
 
 class Translator {
 private:
@@ -34,7 +34,7 @@ public:
         const rust::Vec<VecStr>& source,
         const TranslationOptions& options,
         bool has_callback,
-        DynCallback& callback
+        TranslationCallbackBox& callback
     ) const;
 
     rust::Vec<TranslationResult>
@@ -43,7 +43,7 @@ public:
         const rust::Vec<VecStr>& target_prefix,
         const TranslationOptions& options,
         bool has_callback,
-        DynCallback& callback
+        TranslationCallbackBox& callback
     ) const;
 
     size_t num_queued_batches() const {

--- a/include/translator.h
+++ b/include/translator.h
@@ -46,15 +46,15 @@ public:
         TranslationCallbackBox& callback
     ) const;
 
-    size_t num_queued_batches() const {
+    inline size_t num_queued_batches() const {
         return this->impl->num_queued_batches();
     }
 
-    size_t num_active_batches() const {
+    inline size_t num_active_batches() const {
         return this->impl->num_active_batches();
     }
 
-    size_t num_replicas() const {
+    inline size_t num_replicas() const {
         return this->impl->num_replicas();
     }
 };

--- a/include/translator.h
+++ b/include/translator.h
@@ -19,6 +19,7 @@ struct VecStr;
 struct TranslationOptions;
 struct TranslationResult;
 struct GenerationStepResult;
+struct DynCallback;
 
 class Translator {
 private:
@@ -33,7 +34,7 @@ public:
         const rust::Vec<VecStr>& source,
         const TranslationOptions& options,
         bool has_callback,
-        rust::Fn<bool(GenerationStepResult)> callback
+        DynCallback& callback
     ) const;
 
     rust::Vec<TranslationResult>
@@ -42,7 +43,7 @@ public:
         const rust::Vec<VecStr>& target_prefix,
         const TranslationOptions& options,
         bool has_callback,
-        rust::Fn<bool(GenerationStepResult)> callback
+        DynCallback& callback
     ) const;
 
     size_t num_queued_batches() const {

--- a/include/types.h
+++ b/include/types.h
@@ -1,4 +1,4 @@
-// convert.h
+// types.h
 //
 // Copyright (c) 2023-2024 Junpei Kawamoto
 //
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "ct2rs/src/types.rs.h"
 #include "rust/cxx.h"
 #include <string>
 #include <vector>

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -8,7 +8,7 @@
 
 #include "ct2rs/include/generator.h"
 
-#include "ct2rs/include/convert.h"
+#include "ct2rs/include/types.h"
 #include "ct2rs/src/generator.rs.h"
 
 using rust::Str;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -183,16 +183,19 @@ impl Generator {
     }
 
     /// Number of batches in the work queue.
+    #[inline]
     pub fn num_queued_batches(&self) -> anyhow::Result<usize> {
         self.ptr.num_queued_batches().map_err(Error::from)
     }
 
     /// Number of batches in the work queue or currently processed by a worker.
+    #[inline]
     pub fn num_active_batches(&self) -> anyhow::Result<usize> {
         self.ptr.num_active_batches().map_err(Error::from)
     }
 
     /// Number of parallel replicas.
+    #[inline]
     pub fn num_replicas(&self) -> anyhow::Result<usize> {
         self.ptr.num_replicas().map_err(Error::from)
     }
@@ -341,11 +344,13 @@ impl From<ffi::GenerationResult> for GenerationResult {
 
 impl GenerationResult {
     /// Returns the number of sequences.
+    #[inline]
     pub fn num_sequences(&self) -> usize {
         self.sequences.len()
     }
 
     /// Returns true if this result has scores.
+    #[inline]
     pub fn has_scores(&self) -> bool {
         !self.scores.is_empty()
     }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -80,7 +80,7 @@ mod ffi {
 
         type Config = crate::config::ffi::Config;
         type BatchType = crate::config::ffi::BatchType;
-        type GenerationStepResult<'a> = crate::types::ffi::GenerationStepResult<'a>;
+        type GenerationStepResult = crate::types::ffi::GenerationStepResult;
 
         type Generator;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //! let res = g.generate_batch(
 //!     &vec!["prompt"],
 //!     &GenerationOptions::default(),
+//!     None,
 //! )?;
 //! for r in res {
 //!     println!("{:?}", r.0);
@@ -251,19 +252,22 @@ impl<T: Tokenizer> Generator<T> {
     }
 
     /// Generate texts with the given prompts.
-    pub fn generate_batch<U, V, W>(
+    pub fn generate_batch<'a, U, V, W>(
         &self,
         prompts: &Vec<U>,
         options: &GenerationOptions<V, W>,
+        callback: Option<&'a mut dyn FnMut(GenerationStepResult) -> bool>,
     ) -> Result<Vec<(Vec<String>, Vec<f32>)>>
     where
         U: AsRef<str>,
         V: AsRef<str>,
         W: AsRef<str>,
     {
-        let output = self
-            .generator
-            .generate_batch(&encode_strings(&self.tokenizer, prompts)?, options)?;
+        let output = self.generator.generate_batch(
+            &encode_strings(&self.tokenizer, prompts)?,
+            options,
+            callback,
+        )?;
 
         let mut res = Vec::new();
         for r in output.into_iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,16 +221,19 @@ impl<T: Tokenizer> Translator<T> {
     }
 
     /// Number of batches in the work queue.
+    #[inline]
     pub fn num_queued_batches(&self) -> Result<usize> {
         self.translator.num_queued_batches()
     }
 
     /// Number of batches in the work queue or currently processed by a worker.
+    #[inline]
     pub fn num_active_batches(&self) -> Result<usize> {
         self.translator.num_active_batches()
     }
 
     /// Number of parallel replicas.
+    #[inline]
     pub fn num_replicas(&self) -> Result<usize> {
         self.translator.num_replicas()
     }
@@ -284,16 +287,19 @@ impl<T: Tokenizer> Generator<T> {
     }
 
     /// Number of batches in the work queue.
+    #[inline]
     pub fn num_queued_batches(&self) -> Result<usize> {
         self.generator.num_queued_batches()
     }
 
     /// Number of batches in the work queue or currently processed by a worker.
+    #[inline]
     pub fn num_active_batches(&self) -> Result<usize> {
         self.generator.num_active_batches()
     }
 
     /// Number of parallel replicas.
+    #[inline]
     pub fn num_replicas(&self) -> Result<usize> {
         self.generator.num_replicas()
     }

--- a/src/translator.cpp
+++ b/src/translator.cpp
@@ -8,7 +8,7 @@
 
 #include "ct2rs/include/translator.h"
 
-#include "ct2rs/include/convert.h"
+#include "ct2rs/include/types.h"
 #include "ct2rs/src/translator.rs.h"
 
 using rust::Fn;

--- a/src/translator.cpp
+++ b/src/translator.cpp
@@ -20,14 +20,14 @@ using std::vector;
 
 inline std::function<bool(ctranslate2::GenerationStepResult)> convert_callback(
     bool has_callback,
-    DynCallback& callback
+    TranslationCallbackBox& callback
 ) {
     if (!has_callback) {
         return nullptr;
     }
 
     return [&](ctranslate2::GenerationStepResult res) -> bool {
-        return execute_dyn_callback(
+        return execute_translation_callback(
             callback,
             GenerationStepResult {
                 res.step,
@@ -46,7 +46,7 @@ inline std::function<bool(ctranslate2::GenerationStepResult)> convert_callback(
 inline ctranslate2::TranslationOptions convert_options(
     const TranslationOptions& options,
     bool has_callback,
-    DynCallback& callback
+    TranslationCallbackBox& callback
 ) {
     return ctranslate2::TranslationOptions {
         options.beam_size,
@@ -93,7 +93,7 @@ Vec<TranslationResult> Translator::translate_batch(
     const Vec<VecStr>& source,
     const TranslationOptions& options,
     bool has_callback,
-    DynCallback& callback
+    TranslationCallbackBox& callback
 ) const {
     return convert_results(this->impl->translate_batch(
         from_rust(source),
@@ -108,7 +108,7 @@ Vec<TranslationResult> Translator::translate_batch_with_target_prefix(
     const Vec<VecStr>& target_prefix,
     const TranslationOptions& options,
     bool has_callback,
-    DynCallback& callback
+    TranslationCallbackBox& callback
 ) const {
     return convert_results(this->impl->translate_batch(
         from_rust(source),

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -85,7 +85,7 @@ mod ffi {
 
         type Config = crate::config::ffi::Config;
         type BatchType = crate::config::ffi::BatchType;
-        type GenerationStepResult<'a> = crate::types::ffi::GenerationStepResult<'a>;
+        type GenerationStepResult = crate::types::ffi::GenerationStepResult;
 
         type Translator;
 

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -361,16 +361,19 @@ impl Translator {
     }
 
     /// Number of batches in the work queue.
+    #[inline]
     pub fn num_queued_batches(&self) -> Result<usize> {
         self.ptr.num_queued_batches().map_err(Error::from)
     }
 
     /// Number of batches in the work queue or currently processed by a worker.
+    #[inline]
     pub fn num_active_batches(&self) -> Result<usize> {
         self.ptr.num_active_batches().map_err(Error::from)
     }
 
     /// Number of parallel replicas.
+    #[inline]
     pub fn num_replicas(&self) -> Result<usize> {
         self.ptr.num_replicas().map_err(Error::from)
     }
@@ -396,21 +399,25 @@ impl From<ffi::TranslationResult> for TranslationResult {
 
 impl TranslationResult {
     /// Returns the first translation hypothesis if exists.
+    #[inline]
     pub fn output(&self) -> Option<&Vec<String>> {
         self.hypotheses.first()
     }
 
     /// Returns the score of the first translation hypothesis if exists.
+    #[inline]
     pub fn score(&self) -> Option<f32> {
         self.scores.first().copied()
     }
 
     /// Returns the number of translation hypotheses.
+    #[inline]
     pub fn num_hypotheses(&self) -> usize {
         self.hypotheses.len()
     }
 
     /// Returns true if this result contains scores.
+    #[inline]
     pub fn has_scores(&self) -> bool {
         !self.scores.is_empty()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,6 +50,16 @@ pub(crate) mod ffi {
     }
 }
 
+pub(crate) trait GenerationCallback {
+    fn execute(&mut self, res: ffi::GenerationStepResult) -> bool;
+}
+
+impl<F: FnMut(ffi::GenerationStepResult) -> bool> GenerationCallback for F {
+    fn execute(&mut self, args: ffi::GenerationStepResult) -> bool {
+        self(args)
+    }
+}
+
 #[inline]
 pub(crate) fn vec_ffi_vecstr<T: AsRef<str>>(src: &Vec<Vec<T>>) -> Vec<ffi::VecStr> {
     src.iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,7 @@
 pub(crate) mod ffi {
     /// The result for a single generation step.
     #[derive(Clone, Debug)]
-    pub struct GenerationStepResult{
+    pub struct GenerationStepResult {
         /// The decoding step.
         pub step: usize,
         /// The batch index.
@@ -50,16 +50,6 @@ pub(crate) mod ffi {
     }
 }
 
-pub(crate) trait GenerationCallback {
-    fn execute(&mut self, res: ffi::GenerationStepResult) -> bool;
-}
-
-impl<F: FnMut(ffi::GenerationStepResult) -> bool> GenerationCallback for F {
-    fn execute(&mut self, args: ffi::GenerationStepResult) -> bool {
-        self(args)
-    }
-}
-
 #[inline]
 pub(crate) fn vec_ffi_vecstr<T: AsRef<str>>(src: &Vec<Vec<T>>) -> Vec<ffi::VecStr> {
     src.iter()
@@ -67,10 +57,6 @@ pub(crate) fn vec_ffi_vecstr<T: AsRef<str>>(src: &Vec<Vec<T>>) -> Vec<ffi::VecSt
             v: v.iter().map(|s| s.as_ref()).collect(),
         })
         .collect()
-}
-
-pub(crate) fn noop_callback(_r: ffi::GenerationStepResult) -> bool {
-    false
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,8 +11,8 @@
 #[cxx::bridge]
 pub(crate) mod ffi {
     /// The result for a single generation step.
-    #[derive(Debug)]
-    pub struct GenerationStepResult<'a> {
+    #[derive(Clone, Debug)]
+    pub struct GenerationStepResult{
         /// The decoding step.
         pub step: usize,
         /// The batch index.
@@ -22,7 +22,7 @@ pub(crate) mod ffi {
         /// Index of the hypothesis in the batch.
         pub hypothesis_id: usize,
         /// String value of the generated token.
-        pub token: &'a str,
+        pub token: String,
         /// true if return_log_prob was enabled
         pub has_log_prob: bool,
         /// Log probability of the token.
@@ -62,7 +62,6 @@ pub(crate) fn vec_ffi_vecstr<T: AsRef<str>>(src: &Vec<Vec<T>>) -> Vec<ffi::VecSt
 pub(crate) fn noop_callback(_r: ffi::GenerationStepResult) -> bool {
     false
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR allows users to get step results using a mutable closure:

```rust
use ct2rs::config::Config;
use ct2rs::translator::{Translator, TranslationOptions, GenerationStepResult};

let source_tokens = vec![
    vec!["▁Hall", "o", "▁World", "!", "</s>"],
    vec![
        "▁This", "▁library", "▁is", "▁a", "▁", "Rust", "▁", "binding", "s", "▁of",
        "▁C", "Trans", "late", "2", ".", "</s>"
    ],
];
let options = TranslationOptions::default();
let mut callback = |step_result: GenerationStepResult| -> bool {
    println!("{:?}", step_result);
    false // Continue processing
};
let translator = Translator::new("/path/to/model", &Config::default())
    .expect("Failed to create translator");
let results = translator.translate_batch(&source_tokens, &options, Some(&mut callback))
    .expect("Translation failed");
```