### PR TITLE
fix: static link mkl on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,14 @@ description = "Rust bindings for OpenNMT/CTranslate2"
 [dependencies]
 anyhow = "1.0.86"
 cxx = { version = "1.0.123", features = ["c++17"] }
-intel-mkl-src = { version = "0.8.1", optional = true }
 sentencepiece = "0.11.2"
 tokenizers = "0.19.1"
+
+[target.'cfg(windows)'.dependencies]
+intel-mkl-src = { version = "0.8.1", optional = true, features = ["mkl-static-ilp64-seq"] }
+
+[target.'cfg(unix)'.dependencies]
+intel-mkl-src = { version = "0.8.1", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.5.7", features = ["derive"] }


### PR DESCRIPTION
When enabled mkl on Windows I got linking errors
Enabling this feature fixed it.