### PR TITLE
Bypass dropping UniquePtrs for Translator, Generator, and Whisper on Windows

### DIFF
--- a/src/sys/generator.rs
+++ b/src/sys/generator.rs
@@ -289,6 +289,20 @@ impl Debug for Generator {
     }
 }
 
+// Releasing `UniquePtr<Generator>` invokes joining threads.
+// However, on Windows, this causes a deadlock.
+// As a workaround, it is bypassed here.
+// See also https://github.com/jkawamoto/ctranslate2-rs/issues/64
+#[cfg(target_os = "windows")]
+impl Drop for Generator {
+    fn drop(&mut self) {
+        let ptr = std::mem::replace(&mut self.ptr, UniquePtr::null());
+        unsafe {
+            std::ptr::drop_in_place(ptr.into_raw());
+        }
+    }
+}
+
 /// The set of generation options.
 ///
 /// # Examples

--- a/src/sys/translator.rs
+++ b/src/sys/translator.rs
@@ -560,6 +560,20 @@ impl Debug for Translator {
     }
 }
 
+// Releasing `UniquePtr<Translator>` invokes joining threads.
+// However, on Windows, this causes a deadlock.
+// As a workaround, it is bypassed here.
+// See also https://github.com/jkawamoto/ctranslate2-rs/issues/64
+#[cfg(target_os = "windows")]
+impl Drop for Translator {
+    fn drop(&mut self) {
+        let ptr = std::mem::replace(&mut self.ptr, UniquePtr::null());
+        unsafe {
+            std::ptr::drop_in_place(ptr.into_raw());
+        }
+    }
+}
+
 /// A translation result.
 ///
 /// This struct is a Rust binding to the

--- a/src/sys/whisper.rs
+++ b/src/sys/whisper.rs
@@ -392,6 +392,20 @@ impl Debug for Whisper {
     }
 }
 
+// Releasing `UniquePtr<Whisper>` invokes joining threads.
+// However, on Windows, this causes a deadlock.
+// As a workaround, it is bypassed here.
+// See also https://github.com/jkawamoto/ctranslate2-rs/issues/64
+#[cfg(target_os = "windows")]
+impl Drop for Whisper {
+    fn drop(&mut self) {
+        let ptr = std::mem::replace(&mut self.ptr, UniquePtr::null());
+        unsafe {
+            std::ptr::drop_in_place(ptr.into_raw());
+        }
+    }
+}
+
 unsafe impl Send for ffi::Whisper {}
 unsafe impl Sync for ffi::Whisper {}
 


### PR DESCRIPTION
Releasing `UniquePtr`s for `sys::Translator`, `sys::Generator`, and `sys::Whisper` cause the program to hang on Windows.
This PR bypasses them on Windows as a workaround.

See also: https://github.com/jkawamoto/ctranslate2-rs/issues/64#issuecomment-2236987058