### PR TITLE
Add Hugging Face integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: check-build-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -42,9 +46,9 @@ jobs:
           submodules: recursive
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build -vv --no-default-features -F "whisper,${{ matrix.backend }},${{ matrix.feature }}"
+        run: cargo build -vv --no-default-features -F "whisper,hub,${{ matrix.backend }},${{ matrix.feature }}"
       - name: Run tests
-        run: cargo test -vv --no-default-features -F "whisper,${{ matrix.backend }},${{ matrix.feature }}"
+        run: cargo test -vv --no-default-features -F "whisper,hub,${{ matrix.backend }},${{ matrix.feature }}" -- --include-ignored
 
   build-linux:
     strategy:
@@ -77,9 +81,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build -vv --no-default-features -F "whisper,${{ matrix.backend }},${{ matrix.feature }}"
+        run: cargo build -vv --no-default-features -F "whisper,hub,${{ matrix.backend }},${{ matrix.feature }}"
       - name: Run tests
-        run: cargo test -vv --no-default-features -F "whisper,${{ matrix.backend }},${{ matrix.feature }}"
+        run: cargo test -vv --no-default-features -F "whisper,hub,${{ matrix.backend }},${{ matrix.feature }}" -- --include-ignored
+        if: ${{ matrix.backend != 'mkl' }}
 
   build-windows:
     strategy:
@@ -96,6 +101,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build -vv --no-default-features -F "whisper,${{ matrix.backend }},${{ matrix.feature }}"
+        run: cargo build -vv --no-default-features -F "whisper,hub,${{ matrix.backend }},${{ matrix.feature }}"
       - name: Run tests
-        run: cargo test -vv --no-default-features -F "whisper,${{ matrix.backend }},${{ matrix.feature }}"
+        run: cargo test -vv --no-default-features -F "whisper,hub,${{ matrix.backend }},${{ matrix.feature }}" -- --include-ignored

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ ndarray = { version = "0.15.6", optional = true }
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 serde_json = { version = "1.0.128", optional = true }
 
+# Dependencies for Hugging Face integration
+hf-hub = { version = "0.3.2", optional = true }
+
 [target.'cfg(windows)'.dependencies]
 intel-mkl-src = { version = "0.8.1", optional = true, features = ["mkl-static-ilp64-seq"] }
 
@@ -63,6 +66,7 @@ walkdir = "2.5.0"
 default = ["ruy"]
 whisper = ["dep:mel_spec", "dep:ndarray", "dep:serde", "dep:serde_json"]
 flash-attention = []
+hub = ["dep:hf-hub"]
 
 # Features to select backends.
 mkl = ["dep:intel-mkl-src"]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -239,13 +239,40 @@ impl<T: Tokenizer> Debug for Generator<T> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "hub")]
 mod tests {
     use super::Generator;
+    use crate::{download_model, GenerationOptions};
+
+    const MODEL_ID: &str = "jkawamoto/gpt2-ct2";
+
+    #[test]
+    #[ignore]
+    fn test_generate() {
+        let model_path = download_model(MODEL_ID).unwrap();
+        let g = Generator::new(&model_path, &Default::default()).unwrap();
+
+        let prompt = "CTranslate2 is a library";
+        let res = g
+            .generate_batch(
+                &[prompt],
+                &GenerationOptions {
+                    max_length: 32,
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap();
+
+        assert!(res[0].0[0].starts_with(prompt));
+    }
 
     #[test]
     #[ignore]
     fn test_generator_debug() {
-        let g = Generator::new("data/bloom-560m", &Default::default()).unwrap();
-        assert!(format!("{:?}", g).contains("bloom-560m"));
+        let model_path = download_model(MODEL_ID).unwrap();
+        let g = Generator::new(&model_path, &Default::default()).unwrap();
+
+        assert!(format!("{:?}", g).contains(model_path.file_name().unwrap().to_str().unwrap()));
     }
 }

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -1,0 +1,36 @@
+// hub.rs
+//
+// Copyright (c) 2023-2024 Junpei Kawamoto
+//
+// This software is released under the MIT License.
+//
+// http://opensource.org/licenses/mit-license.php
+
+//! This module provides functions for preparing model files.
+
+use anyhow::{anyhow, Result};
+use hf_hub::api::sync::Api;
+use std::path::PathBuf;
+
+/// Downloads a model by its ID and returns the path to the directory where the model files are stored.
+///
+/// # Arguments
+/// * `model_id` - The ID of the model to be downloaded from Hugging Face.
+///
+/// # Returns
+/// Returns a `PathBuf` pointing to the directory where the model files are stored if the download
+/// is successful. If no model files are found, it returns an error.
+pub fn download_model<T: AsRef<str>>(model_id: T) -> Result<PathBuf> {
+    let api = Api::new()?;
+    let repo = api.model(model_id.as_ref().to_string());
+
+    let mut res = None;
+    for f in repo.info()?.siblings {
+        let path = repo.get(&f.rfilename)?;
+        if res.is_none() {
+            res = path.parent().map(PathBuf::from);
+        }
+    }
+
+    res.ok_or_else(|| anyhow!("no model files are found"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,9 @@
 extern crate intel_mkl_src;
 
 pub use generator::{GenerationOptions, Generator};
+#[cfg(feature = "hub")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hub")))]
+pub use hub::download_model;
 pub use result::GenerationStepResult;
 pub use sys::{set_log_level, set_random_seed, BatchType, ComputeType, Config, Device, LogLevel};
 pub use tokenizer::Tokenizer;
@@ -94,3 +97,7 @@ mod translator;
 #[cfg(feature = "whisper")]
 #[cfg_attr(docsrs, doc(cfg(feature = "whisper")))]
 mod whisper;
+
+#[cfg(feature = "hub")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hub")))]
+mod hub;

--- a/src/sys/generator.rs
+++ b/src/sys/generator.rs
@@ -513,16 +513,7 @@ impl GenerationResult {
 #[cfg(test)]
 mod tests {
     use super::ffi::{VecStr, VecString, VecUSize};
-    use super::Generator;
     use super::{ffi, GenerationOptions, GenerationResult};
-
-    #[test]
-    #[ignore]
-    fn test_generator_debug() {
-        let generator = Generator::new("data/bloom-560m", &Default::default()).unwrap();
-
-        assert!(format!("{:?}", generator).contains("bloom-560m"));
-    }
 
     #[test]
     fn options_to_ffi() {
@@ -624,5 +615,22 @@ mod tests {
         assert!(res.scores.is_empty());
         assert_eq!(res.num_sequences(), 0);
         assert!(!res.has_scores());
+    }
+
+    #[cfg(feature = "hub")]
+    mod hub {
+        use crate::download_model;
+        use crate::sys::Generator;
+
+        const MODEL_ID: &str = "jkawamoto/gpt2-ct2";
+        #[test]
+        #[ignore]
+        fn test_generator_debug() {
+            let model_path = download_model(MODEL_ID).unwrap();
+
+            let generator = Generator::new(&model_path, &Default::default()).unwrap();
+            assert!(format!("{:?}", generator)
+                .contains(model_path.file_name().unwrap().to_str().unwrap()));
+        }
     }
 }

--- a/src/sys/translator.rs
+++ b/src/sys/translator.rs
@@ -629,8 +629,6 @@ impl TranslationResult {
 
 #[cfg(test)]
 mod tests {
-    use crate::sys::Translator;
-
     use super::ffi::{VecStr, VecString};
     use super::{ffi, TranslationOptions, TranslationResult};
 
@@ -728,11 +726,20 @@ mod tests {
         assert!(!res.has_scores());
     }
 
-    #[test]
-    #[ignore]
-    fn test_translator_debug() {
-        let translator = Translator::new("data/t5-small", &Default::default()).unwrap();
+    #[cfg(feature = "hub")]
+    mod hub {
+        use crate::download_model;
+        use crate::sys::Translator;
 
-        assert!(format!("{:?}", translator).contains("t5-small"));
+        const MODEL_ID: &str = "jkawamoto/fugumt-en-ja-ct2";
+        #[test]
+        #[ignore]
+        fn test_translator_debug() {
+            let model_path = download_model(MODEL_ID).unwrap();
+
+            let translator = Translator::new(&model_path, &Default::default()).unwrap();
+            assert!(format!("{:?}", translator)
+                .contains(model_path.file_name().unwrap().to_str().unwrap()));
+        }
     }
 }

--- a/src/sys/whisper.rs
+++ b/src/sys/whisper.rs
@@ -414,7 +414,7 @@ unsafe impl Sync for ffi::Whisper {}
 
 #[cfg(test)]
 mod tests {
-    use super::{ffi, Whisper, WhisperGenerationResult, WhisperOptions};
+    use super::{ffi, WhisperGenerationResult, WhisperOptions};
 
     #[test]
     fn test_default_options() {
@@ -487,11 +487,21 @@ mod tests {
         assert!(!res.has_scores());
     }
 
-    #[test]
-    #[ignore]
-    fn test_whisper_debug() {
-        let whisper = Whisper::new("data/whisper-tiny-ct2", Default::default()).unwrap();
+    #[cfg(feature = "hub")]
+    mod hub {
+        use crate::download_model;
+        use crate::sys::Whisper;
 
-        assert!(format!("{:?}", whisper).contains("whisper-tiny-ct2"));
+        const MODEL_ID: &str = "jkawamoto/whisper-tiny-ct2";
+
+        #[test]
+        #[ignore]
+        fn test_whisper_debug() {
+            let model_path = download_model(MODEL_ID).unwrap();
+
+            let whisper = Whisper::new(&model_path, Default::default()).unwrap();
+            assert!(format!("{:?}", whisper)
+                .contains(model_path.file_name().unwrap().to_str().unwrap()));
+        }
     }
 }

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -325,13 +325,38 @@ impl<T: Tokenizer> Debug for Translator<T> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "hub")]
 mod tests {
-    use crate::Translator;
+    use crate::{download_model, TranslationOptions, Translator};
+
+    const MODEL_ID: &str = "jkawamoto/fugumt-en-ja-ct2";
+
+    #[test]
+    #[ignore]
+    fn test_translate() {
+        let model_path = download_model(MODEL_ID).unwrap();
+        let t = Translator::new(&model_path, &Default::default()).unwrap();
+
+        let res = t
+            .translate_batch(
+                &["Hellow"],
+                &TranslationOptions {
+                    beam_size: 1,
+                    sampling_temperature: 0.,
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(res[0].0, "こんにちは");
+    }
 
     #[test]
     #[ignore]
     fn test_translator_debug() {
-        let t = Translator::new("data/t5-small", &Default::default()).unwrap();
-        assert!(format!("{:?}", t).contains("t5-small"));
+        let model_path = download_model(MODEL_ID).unwrap();
+        let t = Translator::new(&model_path, &Default::default()).unwrap();
+
+        assert!(format!("{:?}", t).contains(model_path.file_name().unwrap().to_str().unwrap()));
     }
 }

--- a/src/whisper.rs
+++ b/src/whisper.rs
@@ -287,13 +287,18 @@ impl PreprocessorConfig {
 }
 
 #[cfg(test)]
+#[cfg(feature = "hub")]
 mod tests {
-    use crate::Whisper;
+    use crate::{download_model, Whisper};
+
+    const MODEL_ID: &str = "jkawamoto/whisper-tiny-ct2";
 
     #[test]
     #[ignore]
-    fn test_generator_debug() {
-        let w = Whisper::new("data/whisper-tiny-ct2", Default::default()).unwrap();
-        assert!(format!("{:?}", w).contains("whisper-tiny-ct2"));
+    fn test_whisper_debug() {
+        let model_path = download_model(MODEL_ID).unwrap();
+        let w = Whisper::new(&model_path, Default::default()).unwrap();
+
+        assert!(format!("{:?}", w).contains(model_path.file_name().unwrap().to_str().unwrap()));
     }
 }


### PR DESCRIPTION
Introduce a new optional feature "hub" that integrates Hugging Face's API using the hf-hub crate. Added `download_model` function in the new `hub` module to enable model file downloads. Adjusted Cargo.toml and library to accommodate these changes.