### PR TITLE
Test should use CUDA if cuda feature is enabled

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -242,7 +242,7 @@ impl<T: Tokenizer> Debug for Generator<T> {
 #[cfg(feature = "hub")]
 mod tests {
     use super::Generator;
-    use crate::{download_model, GenerationOptions};
+    use crate::{download_model, Config, Device, GenerationOptions};
 
     const MODEL_ID: &str = "jkawamoto/gpt2-ct2";
 
@@ -250,7 +250,18 @@ mod tests {
     #[ignore]
     fn test_generate() {
         let model_path = download_model(MODEL_ID).unwrap();
-        let g = Generator::new(&model_path, &Default::default()).unwrap();
+        let g = Generator::new(
+            &model_path,
+            &Config {
+                device: if cfg!(feature = "cuda") {
+                    Device::CUDA
+                } else {
+                    Device::CPU
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let prompt = "CTranslate2 is a library";
         let res = g
@@ -271,7 +282,18 @@ mod tests {
     #[ignore]
     fn test_generator_debug() {
         let model_path = download_model(MODEL_ID).unwrap();
-        let g = Generator::new(&model_path, &Default::default()).unwrap();
+        let g = Generator::new(
+            &model_path,
+            &Config {
+                device: if cfg!(feature = "cuda") {
+                    Device::CUDA
+                } else {
+                    Device::CPU
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         assert!(format!("{:?}", g).contains(model_path.file_name().unwrap().to_str().unwrap()));
     }

--- a/src/sys/generator.rs
+++ b/src/sys/generator.rs
@@ -619,8 +619,8 @@ mod tests {
 
     #[cfg(feature = "hub")]
     mod hub {
-        use crate::download_model;
         use crate::sys::Generator;
+        use crate::{download_model, Config, Device};
 
         const MODEL_ID: &str = "jkawamoto/gpt2-ct2";
         #[test]
@@ -628,7 +628,18 @@ mod tests {
         fn test_generator_debug() {
             let model_path = download_model(MODEL_ID).unwrap();
 
-            let generator = Generator::new(&model_path, &Default::default()).unwrap();
+            let generator = Generator::new(
+                &model_path,
+                &Config {
+                    device: if cfg!(feature = "cuda") {
+                        Device::CUDA
+                    } else {
+                        Device::CPU
+                    },
+                    ..Default::default()
+                },
+            )
+            .unwrap();
             assert!(format!("{:?}", generator)
                 .contains(model_path.file_name().unwrap().to_str().unwrap()));
         }

--- a/src/sys/translator.rs
+++ b/src/sys/translator.rs
@@ -728,8 +728,8 @@ mod tests {
 
     #[cfg(feature = "hub")]
     mod hub {
-        use crate::download_model;
         use crate::sys::Translator;
+        use crate::{download_model, Config, Device};
 
         const MODEL_ID: &str = "jkawamoto/fugumt-en-ja-ct2";
         #[test]
@@ -737,7 +737,18 @@ mod tests {
         fn test_translator_debug() {
             let model_path = download_model(MODEL_ID).unwrap();
 
-            let translator = Translator::new(&model_path, &Default::default()).unwrap();
+            let translator = Translator::new(
+                &model_path,
+                &Config {
+                    device: if cfg!(feature = "cuda") {
+                        Device::CUDA
+                    } else {
+                        Device::CPU
+                    },
+                    ..Default::default()
+                },
+            )
+            .unwrap();
             assert!(format!("{:?}", translator)
                 .contains(model_path.file_name().unwrap().to_str().unwrap()));
         }

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -327,7 +327,7 @@ impl<T: Tokenizer> Debug for Translator<T> {
 #[cfg(test)]
 #[cfg(feature = "hub")]
 mod tests {
-    use crate::{download_model, TranslationOptions, Translator};
+    use crate::{download_model, Config, Device, TranslationOptions, Translator};
 
     const MODEL_ID: &str = "jkawamoto/fugumt-en-ja-ct2";
 
@@ -335,7 +335,18 @@ mod tests {
     #[ignore]
     fn test_translate() {
         let model_path = download_model(MODEL_ID).unwrap();
-        let t = Translator::new(&model_path, &Default::default()).unwrap();
+        let t = Translator::new(
+            &model_path,
+            &Config {
+                device: if cfg!(feature = "cuda") {
+                    Device::CUDA
+                } else {
+                    Device::CPU
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let res = t
             .translate_batch(
@@ -355,7 +366,18 @@ mod tests {
     #[ignore]
     fn test_translator_debug() {
         let model_path = download_model(MODEL_ID).unwrap();
-        let t = Translator::new(&model_path, &Default::default()).unwrap();
+        let t = Translator::new(
+            &model_path,
+            &Config {
+                device: if cfg!(feature = "cuda") {
+                    Device::CUDA
+                } else {
+                    Device::CPU
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         assert!(format!("{:?}", t).contains(model_path.file_name().unwrap().to_str().unwrap()));
     }

--- a/src/whisper.rs
+++ b/src/whisper.rs
@@ -295,7 +295,7 @@ impl PreprocessorConfig {
 #[cfg(test)]
 #[cfg(feature = "hub")]
 mod tests {
-    use crate::{download_model, Whisper};
+    use crate::{download_model, Config, Device, Whisper};
 
     const MODEL_ID: &str = "jkawamoto/whisper-tiny-ct2";
 
@@ -303,7 +303,18 @@ mod tests {
     #[ignore]
     fn test_whisper_debug() {
         let model_path = download_model(MODEL_ID).unwrap();
-        let w = Whisper::new(&model_path, Default::default()).unwrap();
+        let w = Whisper::new(
+            &model_path,
+            Config {
+                device: if cfg!(feature = "cuda") {
+                    Device::CUDA
+                } else {
+                    Device::CPU
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         assert!(format!("{:?}", w).contains(model_path.file_name().unwrap().to_str().unwrap()));
     }


### PR DESCRIPTION
Updated test configurations for Translator and Generator to use CUDA device when the `cuda` feature is enabled; defaulting to CPU otherwise. This ensures that tests are run on the appropriate device based on the feature flag.