### PR TITLE
Stop hardcoding static linking of the C runtime on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ and [Apple Accelerate](https://developer.apple.com/documentation/accelerate).
 
 The installation of CMake is required to compile the library.
 
-Additional notes for Windows:
-it is necessary to add `RUSTFLAGS=-C target-feature=+crt-static` to the environment variables for compilation.
+**Additional notes for Windows**:
+Setting the environment variable `RUSTFLAGS=-C target-feature=+crt-static` might be required.
 
 ## Model Conversion for CTranslate2
 

--- a/build.rs
+++ b/build.rs
@@ -173,7 +173,7 @@ fn main() {
     if os == Os::Win {
         let rustflags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
         if !rustflags.contains("target-feature=+crt-static") {
-            println!("cargo:warning=For Windows compilation, set `RUSTFLAGS=-C target-feature=+crt-static`.");
+            println!("cargo:warning=For Windows compilation, setting the environment variable `RUSTFLAGS=-C target-feature=+crt-static` might be required.");
         }
 
         println!("cargo::rustc-link-arg=/FORCE:MULTIPLE");
@@ -266,7 +266,6 @@ fn main() {
     .file("src/sys/whisper.cpp")
     .include("CTranslate2/include")
     .std("c++17")
-    .static_crt(cfg!(target_os = "windows"))
     .flag_if_supported("/EHsc")
     .compile("ct2rs");
 }


### PR DESCRIPTION
This pull request refactors the Windows build configuration by removing the hardcoded static linking of the C runtime (`+crt-static`). Users are now provided with the flexibility to configure linking behavior through environment variables or project settings, ensuring better adaptability to diverse build environments.