### PR TITLE
Specify required features for `opt` and `whisper` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ name = "gpt-neox"
 
 [[example]]
 name = "opt"
+required-features = ["tokenizers"]
 
 [[example]]
 name = "t5"
@@ -134,6 +135,7 @@ name = "stream"
 
 [[example]]
 name = "whisper"
+required-features = ["whisper"]
 
 [package.metadata.docs.rs]
 features = ["whisper", "hub"]


### PR DESCRIPTION
This pull request updates the `Cargo.toml` file to include the required features for the `opt` and `whisper` examples. This ensures clarity on dependencies and proper functionality when building these examples.