### PR TITLE
Integrate OpenBLAS support with static linking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,14 +30,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install OpenBLAS
-        if: ${{ matrix.backend == 'openblas' }}
-        run: |
-          brew install openblas
-          PREFIX=$(brew --prefix openblas)
-          echo "LIBRARY_PATH=$PREFIX/lib:$LIBRARY_PATH" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "CMAKE_PREFIX_PATH=$PREFIX:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -64,11 +56,6 @@ jobs:
       LIBRARY_PATH: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - name: Install OpenBLAS
-        if: ${{ matrix.backend == 'openblas' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake libclang-dev libopenblas-dev
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -104,6 +91,7 @@ jobs:
         if: ${{ matrix.backend == 'openblas' }}
         run: |
           vcpkg install openblas:x64-windows-static
+          vcpkg integrate install
           echo "CMAKE_INCLUDE_PATH=$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows-static/include/openblas;$env:CMAKE_INCLUDE_PATH" >> $env:GITHUB_ENV
           echo "CMAKE_LIBRARY_PATH=$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows-static/lib;$env:CMAKE_LIBRARY_PATH" >> $env:GITHUB_ENV
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Setting the environment variable `RUSTFLAGS=-C target-feature=+crt-static` might
 The above features require setting the `CUDA_TOOLKIT_ROOT_DIR` environment variable appropriately.
 
 - `mkl`: Enables [Intel MKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) support
-- `openblas`: Enables [OpenBLAS](https://www.openblas.net/) support
+- `openblas`: Enables [OpenBLAS](https://www.openblas.net/) support (OpenBLAS needs to be installed manually
+  via [vcpkg](https://vcpkg.io) on Windows)
 - `dnnl`: Enables [oneDNN](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onednn.html) support
 - `ruy`: Enables [Ruy](https://github.com/google/ruy) support
 - `accelerate`: Enables [Apple Accelerate](https://developer.apple.com/documentation/accelerate) support (macOS only)

--- a/ct2rs/Cargo.toml
+++ b/ct2rs/Cargo.toml
@@ -47,6 +47,12 @@ serde_json = { version = "1.0", optional = true }
 # Dependencies for Hugging Face integration
 hf-hub = { version = "0.4", optional = true }
 
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+openblas-src = { version = "0.10.13", features = ["static"], optional = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+openblas-src = { version = "0.10.13", features = ["static", "system"], optional = true }
+
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive"] }
 rand = "0.9.1"
@@ -74,7 +80,7 @@ hub = ["dep:hf-hub"]
 cuda = []
 cudnn = ["cuda"]
 mkl = ["dep:intel-onemkl-prebuild"]
-openblas = []
+openblas = ["dep:openblas-src"]
 dnnl = ["dep:onednn-src"]
 ruy = []
 accelerate = []

--- a/ct2rs/build.rs
+++ b/ct2rs/build.rs
@@ -133,8 +133,11 @@ fn main() {
         cmake.env("MKLROOT", env::var("DEP_MKL_ROOT").unwrap());
     }
     if openblas {
-        println!("cargo:rustc-link-lib=static=openblas");
         cmake.define("WITH_OPENBLAS", "ON");
+        if os != Os::Win {
+            include_paths.push(PathBuf::from(env::var("DEP_OPENBLAS_INCLUDE").unwrap()));
+            library_paths.push(PathBuf::from(env::var("DEP_OPENBLAS_LIBRARY").unwrap()));
+        }
     }
     if ruy {
         cmake.define("WITH_RUY", "ON");

--- a/ct2rs/src/lib.rs
+++ b/ct2rs/src/lib.rs
@@ -75,6 +75,9 @@
 #[cfg(feature = "mkl")]
 extern crate intel_onemkl_prebuild;
 
+#[cfg(feature = "openblas")]
+extern crate openblas_src;
+
 #[cfg(feature = "dnnl")]
 extern crate onednn_src;
 


### PR DESCRIPTION
Added OpenBLAS integration using the `openblas-src` crate with static linking. This includes updates to the build script and adjustments to feature flags in `Cargo.toml`. Changes aim to ensure compatibility and streamlined integration across platforms.