### PR TITLE
Add `system` feature for external CTranslate2 library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ If you want to use platform-specific default features, use the `ct2rs-platform` 
 
 - `whisper`: Enables [Whisper](https://huggingface.co/docs/transformers/model_doc/whisper) model support
 - `hub`: Enables [HuggingFace Hub](https://huggingface.co/docs/hub) integration
+- `system`: Skip compiling CTranslate2 and use the system's pre-installed shared library instead (requires setting the
+  appropriate environment variables to locate the CTranslate2 shared library)
 
 ### Platform Specific Features
 

--- a/ct2rs/Cargo.toml
+++ b/ct2rs/Cargo.toml
@@ -75,6 +75,7 @@ whisper = [
     "all-tokenizers",
 ]
 hub = ["dep:hf-hub"]
+system = []
 
 # Features to select backends.
 cuda = []

--- a/ct2rs/build.rs
+++ b/ct2rs/build.rs
@@ -31,15 +31,7 @@ enum Os {
     Unknown,
 }
 
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=src/sys");
-    println!("cargo:rerun-if-changed=include");
-    println!("cargo:rerun-if-changed=CTranslate2");
-    add_search_paths("LIBRARY_PATH");
-    println!("cargo:rerun-if-env-changed=CMAKE_INCLUDE_PATH");
-    add_search_paths("CMAKE_LIBRARY_PATH");
-
+fn build_ctranslate2() {
     let mut cmake = Config::new("CTranslate2");
     let os = if cfg!(target_os = "windows") {
         Os::Win
@@ -183,6 +175,22 @@ fn main() {
 
     let ctranslate2 = cmake.build();
     link_libraries(ctranslate2.join("build"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/sys");
+    println!("cargo:rerun-if-changed=include");
+    println!("cargo:rerun-if-changed=CTranslate2");
+    add_search_paths("LIBRARY_PATH");
+    println!("cargo:rerun-if-env-changed=CMAKE_INCLUDE_PATH");
+    add_search_paths("CMAKE_LIBRARY_PATH");
+
+    if cfg!(feature = "system") {
+        println!("cargo:rustc-link-lib=ctranslate2");
+    } else {
+        build_ctranslate2()
+    }
 
     cxx_build::bridges([
         "src/sys/types.rs",


### PR DESCRIPTION
This pull request introduces a new `system` feature for the CTranslate2 library. When enabled, this feature allows the use of a pre-installed shared library instead of compiling the library during the build process. The following changes are included:

- Add `system` feature flag in the build process.
- Update the build script to handle the `system` feature.
- Modify README to document how to use the new feature.
