### PR TITLE
CMake options for CUDA switched

### DIFF
--- a/ct2rs/build.rs
+++ b/ct2rs/build.rs
@@ -42,7 +42,9 @@ fn main() {
 
     let mut cmake = Config::new("CTranslate2");
     match env::var("CMAKE_PARALLEL") {
-        Ok(job_n) => { cmake.build_arg("-j").build_arg(job_n); },
+        Ok(job_n) => {
+            cmake.build_arg("-j").build_arg(job_n);
+        }
         Err(env::VarError::NotPresent) => (),
         Err(err) => panic!("CMAKE_PARALLEL format error: {:?}", err),
     }


### PR DESCRIPTION
Two CMake options for configuring building with CUDA seem to have been switched:
- CUDA_TOOLKIT_ROOT_DIR should be the path to where CUDA is installed, while
- CUDA_ARCH_LIST should be a list of architectures, where "Common" triggers the use of a bunch of common architectures.

The cuda compiler can use quite a bit of memory, and I experienced several OOM crashes due to cmake allocating one job per CPU core without regard to process memory usage. This PR also adds a build environment variable CMAKE_PARALLEL which, if set, adds the "-j <parallel_job_num>" option to cmake, so that cmake's job parallelism can be controlled to limit memory usage.