### PR TITLE
Bump version and improve CI and documentation

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.9.8"
+current_version = "0.9.9"
 commit = true
 tag = false
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,3 +111,15 @@ jobs:
       - name: Run tests
         run: cargo test -vv -p ct2rs --no-default-features -F "all-tokenizers,whisper,hub,${{ matrix.backend }}" -- --include-ignored
         if: ${{ matrix.backend != 'mkl' }}
+
+  docs:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: |
+          cargo +nightly rustdoc -F whisper,hub -vv -p ct2rs -- --cfg docsrs
+          cargo +nightly rustdoc -F whisper,hub -vv -p ct2rs-platform -- --cfg docsrs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ct2rs", "ct2rs-platform"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.8"
+version = "0.9.9"
 authors = ["Junpei Kawamoto <kawamoto.junpei@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Add this crate to your `Cargo.toml` with selecting the backends you want to use 
 
 ```toml
 [dependencies]
-ct2rs = { version = "0.9.8", features = ["cuda", "dnnl", "mkl"] }
+ct2rs = { version = "0.9.9", features = ["cuda", "dnnl", "mkl"] }
 ```
 
 Or you can use platform-specific default features by using the `ct2rs-platform` crate:
 
 ```toml
 [dependencies]
-ct2rs = { version = "0.9.8", package = "ct2rs-platform" }
+ct2rs = { version = "0.9.9", package = "ct2rs-platform" }
 ```
 
 If you want [Whisper](https://huggingface.co/docs/transformers/model_doc/whisper) model support,

--- a/ct2rs-platform/Cargo.toml
+++ b/ct2rs-platform/Cargo.toml
@@ -11,31 +11,31 @@ repository.workspace = true
 description = "Platform-specific default feature sets for ct2rs"
 
 [target.'cfg(target_os = "windows")'.dependencies.ct2rs]
-version = "=0.9.8"
+version = "=0.9.9"
 path = "../ct2rs"
 default-features = false
 features = ["openmp-runtime-intel", "dnnl", "cuda", "cudnn", "cuda-dynamic-loading", "mkl"]
 
 [target.'cfg(all(target_os = "macos", not(target_arch = "aarch64")))'.dependencies.ct2rs]
-version = "=0.9.8"
+version = "=0.9.9"
 path = "../ct2rs"
 default-features = false
 features = ["dnnl", "mkl"]
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies.ct2rs]
-version = "=0.9.8"
+version = "=0.9.9"
 path = "../ct2rs"
 default-features = false
 features = ["accelerate", "ruy"]
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "aarch64")))'.dependencies.ct2rs]
-version = "=0.9.8"
+version = "=0.9.9"
 path = "../ct2rs"
 default-features = false
 features = ["dnnl", "openmp-runtime-comp", "cuda", "cudnn", "cuda-dynamic-loading", "mkl", "tensor-parallel", "msse4_1"]
 
 [target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies.ct2rs]
-version = "=0.9.8"
+version = "=0.9.9"
 path = "../ct2rs"
 default-features = false
 features = ["openmp-runtime-comp", "openblas", "ruy"]

--- a/ct2rs-platform/README.md
+++ b/ct2rs-platform/README.md
@@ -9,7 +9,7 @@ Add this crate as the `package` argument of the `ct2rs` crate in your `Cargo.tom
 
 ```toml
 [dependencies]
-ct2rs = { package = "ct2rs-platform", version = "0.9.8" }
+ct2rs = { package = "ct2rs-platform", version = "0.9.9" }
 ```
 
 See the [ct2rs crate](../README.md) for more information.

--- a/ct2rs/src/sys/model_memory_reader.rs
+++ b/ct2rs/src/sys/model_memory_reader.rs
@@ -31,9 +31,6 @@ pub(crate) mod ffi {
 }
 
 /// An allocated buffer with shape information.
-///
-/// This struct is a Rust binding to the
-/// [`ctranslate2::StorageView`](https://opennmt.net/CTranslate2/python/ctranslate2.StorageView.html).
 pub struct ModelMemoryReader {
     ptr: UniquePtr<ffi::ModelMemoryReader>,
     model_name: String,

--- a/ct2rs/src/sys/whisper.rs
+++ b/ct2rs/src/sys/whisper.rs
@@ -428,9 +428,9 @@ impl Whisper {
     /// token time.
     ///
     /// # Arguments
-    /// - `encoder_output` - [`StorageView`] consisting of encoder output created
+    /// * `encoder_output` - [`StorageView`] consisting of encoder output created
     ///   by encode() and provided to generate().
-    /// * `start_sequence` - TODO
+    /// * `start_sequence` - The start sequence tokens.
     /// * `text_tokens` - Vec of tokens for each sequence in the batch.
     /// * `num_frames` - Number of encoder frames in each sequence of the batch.
     /// * `median_filter_width` - Width of the median filter used by the DTW


### PR DESCRIPTION
This pull request includes the following updates:
- **Bump version** from `0.9.8` to `0.9.9`.
- **CI Improvements**:
  - Added a docs generation/build job to the workflow.
  - Switched release jobs to macOS.
- **Documentation Enhancements**:
  - Refined comments in `model_memory_reader` for clarity.
  - Improved parameter descriptions in `whisper.rs` to foster consistency and quality.
