### PR TITLE
Update pre-commit hook and bump version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.9.9"
+current_version = "0.9.10"
 commit = true
 tag = false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.0
+    rev: v21.1.1
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["ct2rs", "ct2rs-platform"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.9"
+version = "0.9.10"
 authors = ["Junpei Kawamoto <kawamoto.junpei@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Add this crate to your `Cargo.toml` with selecting the backends you want to use 
 
 ```toml
 [dependencies]
-ct2rs = { version = "0.9.9", features = ["cuda", "dnnl", "mkl"] }
+ct2rs = { version = "0.9.10", features = ["cuda", "dnnl", "mkl"] }
 ```
 
 Or you can use platform-specific default features by using the `ct2rs-platform` crate:
 
 ```toml
 [dependencies]
-ct2rs = { version = "0.9.9", package = "ct2rs-platform" }
+ct2rs = { version = "0.9.10", package = "ct2rs-platform" }
 ```
 
 If you want [Whisper](https://huggingface.co/docs/transformers/model_doc/whisper) model support,

--- a/ct2rs-platform/Cargo.toml
+++ b/ct2rs-platform/Cargo.toml
@@ -11,31 +11,31 @@ repository.workspace = true
 description = "Platform-specific default feature sets for ct2rs"
 
 [target.'cfg(target_os = "windows")'.dependencies.ct2rs]
-version = "=0.9.9"
+version = "=0.9.10"
 path = "../ct2rs"
 default-features = false
 features = ["openmp-runtime-intel", "dnnl", "cuda", "cudnn", "cuda-dynamic-loading", "mkl"]
 
 [target.'cfg(all(target_os = "macos", not(target_arch = "aarch64")))'.dependencies.ct2rs]
-version = "=0.9.9"
+version = "=0.9.10"
 path = "../ct2rs"
 default-features = false
 features = ["dnnl", "mkl"]
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies.ct2rs]
-version = "=0.9.9"
+version = "=0.9.10"
 path = "../ct2rs"
 default-features = false
 features = ["accelerate", "ruy"]
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "aarch64")))'.dependencies.ct2rs]
-version = "=0.9.9"
+version = "=0.9.10"
 path = "../ct2rs"
 default-features = false
 features = ["dnnl", "openmp-runtime-comp", "cuda", "cudnn", "cuda-dynamic-loading", "mkl", "tensor-parallel", "msse4_1"]
 
 [target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies.ct2rs]
-version = "=0.9.9"
+version = "=0.9.10"
 path = "../ct2rs"
 default-features = false
 features = ["openmp-runtime-comp", "openblas", "ruy"]

--- a/ct2rs-platform/README.md
+++ b/ct2rs-platform/README.md
@@ -9,7 +9,7 @@ Add this crate as the `package` argument of the `ct2rs` crate in your `Cargo.tom
 
 ```toml
 [dependencies]
-ct2rs = { package = "ct2rs-platform", version = "0.9.9" }
+ct2rs = { package = "ct2rs-platform", version = "0.9.10" }
 ```
 
 See the [ct2rs crate](../README.md) for more information.


### PR DESCRIPTION
- Updated `clang-format` pre-commit hook to v21.1.1 to align with the latest formatting standards.
- Bumped application version from 0.9.9 to 0.9.10 to reflect updated dependencies.
