### PR TITLE
Add `disable-cpu-dispatch` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The above features require setting the `CUDA_TOOLKIT_ROOT_DIR` environment varia
 - `accelerate`: Enables [Apple Accelerate](https://developer.apple.com/documentation/accelerate) support (macOS only)
 - `openmp-runtime-comp`: Enables OpenMP runtime support
 - `openmp-runtime-intel`: Enables OpenMP runtime support for Intel compilers
+- `disable-cpu-dispatch`: Disables CPU kernel dispatching at runtime (should be set when explicitly targeting an
+  architecture)
 
 Multiple features can be enabled at the same time.
 

--- a/ct2rs-platform/Cargo.toml
+++ b/ct2rs-platform/Cargo.toml
@@ -57,6 +57,7 @@ ruy = ["ct2rs/ruy"]
 accelerate = ["ct2rs/accelerate"]
 cuda = ["ct2rs/cuda"]
 cudnn = ["ct2rs/cudnn"]
+disable-cpu-dispatch = ["ct2rs/disable-cpu-dispatch"]
 
 # Features to enable GPU functionality.
 flash-attention = ["ct2rs/flash-attention"]

--- a/ct2rs/Cargo.toml
+++ b/ct2rs/Cargo.toml
@@ -88,6 +88,7 @@ ruy = []
 accelerate = []
 openmp-runtime-comp = []
 openmp-runtime-intel = []
+disable-cpu-dispatch = []
 
 # Features to enable GPU functionality.
 flash-attention = []

--- a/ct2rs/build.rs
+++ b/ct2rs/build.rs
@@ -180,6 +180,9 @@ fn build_ctranslate2() {
     if flash_attention {
         cmake.define("WITH_FLASH_ATTN", "ON");
     }
+    if cfg!(feature = "disable-cpu-dispatch") {
+        cmake.define("ENABLE_CPU_DISPATCH", "OFF");
+    }
 
     if !include_paths.is_empty() {
         cmake.env(


### PR DESCRIPTION
This pull request introduces a new feature `disable-cpu-dispatch` to provide an option for disabling runtime CPU kernel dispatching. This change is intended to give users more control over runtime behavior and improve compatibility in specific deployment environments.

Relate to #127